### PR TITLE
Detect files where L::TT::I put them

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -28,15 +28,7 @@ my $builder = Module::Build->new(
 my ( $treetagger_base_path, $treetagger_prog_path, $tokenizer_prog_path );
 my ( $treetagger_lib_path, $test_language );
 
-# Check if File::Which is installed...
-eval { require File::Which; };
-
-# If File::Which is installed, try to find the TreeTagger executable in PATH.
-if ( ! $@ ) {
-
-    use File::Which;
-    $treetagger_prog_path = which( 'tree-tagger' );
-}
+$treetagger_prog_path = which( 'tree-tagger' );
 
 # If TreeTagger was found in PATH...
 if ( defined $treetagger_prog_path ) {
@@ -107,6 +99,14 @@ if ( -d dir( $treetagger_base_path, 'lib' ) ) {
     # Try to find TreeTagger parameters file in there...
     @installed_parameter_files
         = get_installed_parameter_files( $treetagger_lib_path );
+
+    if (!@installed_parameter_files) {
+        # Try to guess where Lingua::TreeTagger::Installer would put them
+        my $p = $builder->install_destination('lib');
+        $treetagger_lib_path = dir ( $p, 'treetagger');
+        @installed_parameter_files
+          = get_installed_parameter_files( $treetagger_lib_path );
+    }
 }
 
 # If there is no parameter file...
@@ -128,11 +128,11 @@ if ( @installed_parameter_files == 0 ) {
         $prompted_treetagger_lib_path = Module::Build->prompt(
             "Please enter the full path to the TreeTagger 'lib' directory:"
         );
-        
+
         @installed_parameter_files
             = get_installed_parameter_files( $prompted_treetagger_lib_path );
     }
-    
+
     # Then store the prompted path.
     $treetagger_lib_path = $prompted_treetagger_lib_path;
 
@@ -153,6 +153,12 @@ $test_language =~ s/\.par//;
 # Set default path for script tokenize.pl.
 my $default_tokenizer_prog_path
     = file( $treetagger_base_path, 'cmd', 'tokenize.pl' );
+
+if (!-e $default_tokenizer_prog_path) {
+    # try to guess where Lingua::TreeTagger::Installer would put it
+    my $p = $builder->install_destination("bin");
+    $default_tokenizer_prog_path = file($p, 'treetagger', 'tokenize.pl');
+}
 
 # If tokenize.pl is at that location...
 if ( -e $default_tokenizer_prog_path ) {


### PR DESCRIPTION
Hello,

I changed Build.PL to detect files where Lingua::TreeTagger::Installer puts them.
Also, changed a bit on the top regarding File::Which. If you use it, then it is required. No matter what you test or not.

Cheers
Alberto
