### PR TITLE
Moose latest version "Passing a list of values to enum is deprecated".

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -19,7 +19,7 @@ my $builder = Module::Build->new(
         'File::Temp'        => 0.19,
     },
     requires => {
-        'Moose'             => 0,
+        'Moose'             => '2.1213',
         'Path::Class'       => 0,
         'File::Temp'        => 0.19,
     },

--- a/lib/Lingua/TreeTagger.pm
+++ b/lib/Lingua/TreeTagger.pm
@@ -35,11 +35,11 @@ our $_tokenizer_prog_path
 # purposes than part-of-speech tagging. Note that option '-quiet' is always
 # selected.
 
-enum 'treetagger_option' => qw(
+enum 'treetagger_option' => [qw(
     -token              -lemma              -sgml               -ignore-prefix
     -no-unknown         -cap-heuristics     -hyphen-heuristics  -pt-with-lemma
     -pt-with-prob       -base
-);
+)];
 
 
 #===============================================================================


### PR DESCRIPTION
Hello.

Moose latest version "Passing a list of values to enum is deprecated".

error:

```
Passing a list of values to enum is deprecated. Enum values should be wrapped in an arrayref. at local/lib/perl5/x86_64-linux/Moose/Util/TypeConstraints.pm line 437.
        Moose::Util::TypeConstraints::enum("treetagger_option", "-token", "-lemma", "-sgml", "-ignore-prefix", "-no-unknown", "-cap-heuristics", "-hyphen-heuristics", "-pt-with
-lemma", ...) called at local/lib/perl5/Lingua/TreeTagger.pm line 38
```
