### PR TITLE
Use proper path to utf8 tokenizer

### DIFF
--- a/t/utf8.t
+++ b/t/utf8.t
@@ -14,8 +14,11 @@ use File::Temp qw();
 my $utf8_test_lang = 'french';
 my $testparamfile = file( $Lingua::TreeTagger::_treetagger_lib_path, 
     $utf8_test_lang . '-utf8.par' );
-my $testtokenizer = file( $Lingua::TreeTagger::_tokenizer_prog_path, 
-    'utf8-tokenize.perl' );
+
+my $default_tokenizer = $Lingua::TreeTagger::_tokenizer_prog_path;
+$default_tokenizer =~ s/tokenize\.pl$/utf8-tokenize.perl/;
+my $testtokenizer = file( $default_tokenizer );
+
 if( -e $testparamfile && -e $testtokenizer ) {
     plan tests => 14;
 }


### PR DESCRIPTION
As far as I can tell, this test file was never tested in any operating system. Basically, `$Lingua::TreeTagger::_tokenizer_prog_path` is the full path, including file name, for the default tokenizer. Up to now, you were just concatenating, at the end, the utf8 tokenizer filename, resulting on paths like: `/opt/perl/bin/treetagger/tokenize.pl/utf8-tokenize.perl` instead of the correct `/opt/perl/bin/treetagger/utf8-tokenize.perl`

This patch fixes that.