### PR TITLE
Fix tests

### DIFF
--- a/lib/Lingua/TreeTagger/TaggedText.pm
+++ b/lib/Lingua/TreeTagger/TaggedText.pm
@@ -290,7 +290,7 @@ sub as_XML {
             $string .= '<' . $element;
 
             REQUESTED_ATTRIBUTES:
-            foreach my $requested_attribute (keys %requested_attributes) {
+            foreach my $requested_attribute (sort keys %requested_attributes) {
 
                 my $attribute_value =
                     $requested_attribute eq 'original' ? $token->original()

--- a/t/TaggedText.t
+++ b/t/TaggedText.t
@@ -34,7 +34,7 @@ like(
 
 
 my $tagger = eval { Lingua::TreeTagger->new(
-    'language' => 'english',
+    'language' => 'english-utf8',
 ) };
 
 SKIP: {
@@ -126,9 +126,9 @@ SKIP: {
             } ),
             'eq',
                 qq{<lines>\n}
-              . qq{<foo bar="original1" baz="lemma1">tag1</foo>\n}
-              . qq{<foo bar="original2" baz="lemma2">tag2</foo>\n}
-              . qq{<foo bar="original3" baz="lemma3">tag3</foo>\n}
+              . qq{<foo baz="lemma1" bar="original1">tag1</foo>\n}
+              . qq{<foo baz="lemma2" bar="original2">tag2</foo>\n}
+              . qq{<foo baz="lemma3" bar="original3">tag3</foo>\n}
               . qq{</lines>\n},
             'method as_XML works fine with custom settings'
         );

--- a/t/TreeTagger.t
+++ b/t/TreeTagger.t
@@ -137,7 +137,7 @@ ok(
 
 my $tagger_with_custom_tokenizer = eval {
     Lingua::TreeTagger->new(
-                            'language'  => 'english',
+                            'language'  => 'english-utf8',
                             'tokenizer' => \&my_tokenizer,
                            )
   };


### PR DESCRIPTION
In the TreeTagger page the english iso-8859-1 parameter file is no longer available (just the utf-8 one). Also, because Perl randomizes the order of hash keys, I added a sort in the serialization, `as_XML`. So we can compare properly the generated XML file with a predefined test.

If you could merge the three PRs and release, it would be great.

Happy to change anything if you like.